### PR TITLE
Enable support for tables

### DIFF
--- a/markdown_pdf/__init__.py
+++ b/markdown_pdf/__init__.py
@@ -38,7 +38,7 @@ class MarkdownPdf:
 
         # zero, commonmark, js-default, gfm-like
         # https://markdown-it-py.readthedocs.io/en/latest/using.html#quick-start
-        self.m_d = (MarkdownIt(mode))
+        self.m_d = (MarkdownIt(mode).enable('table')) # Enable support for tables
 
         self.out_file = io.BytesIO()
         self.writer = fitz.DocumentWriter(self.out_file)


### PR DESCRIPTION
Can be checked here:
https://github.com/executablebooks/markdown-it-py?tab=readme-ov-file#python-api-usage

![image](https://github.com/vb64/markdown-pdf/assets/27774290/779ef35c-d946-4c51-8280-f9d549a0813d)
