### PR TITLE
Fixed segmentation fault with empty markdown heading.

### DIFF
--- a/history.txt
+++ b/history.txt
@@ -1,5 +1,7 @@
 + Method `add_section` returns content of added section as html string.
 
+- Fixed segmentation fault with empty markdown heading (bump PyMuPDF up to 1.24.6).
+
 22.12.2024 ver.1.3.2
 --------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyMuPDF==1.24.2
+PyMuPDF==1.24.6
 markdown-it-py==3.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,5 +19,5 @@ package_dir =
 packages = markdown_pdf
 python_requires = >=3.8
 install_requires = 
-    PyMuPDF==1.24.2
+    PyMuPDF==1.24.6
     markdown-it-py==3.0.0

--- a/tests/test/test_converter.py
+++ b/tests/test/test_converter.py
@@ -62,3 +62,11 @@ class TestConverter(TestBase):
 
         file_path = Path(self.build('output.pdf'))
         pdf.save(file_path)
+
+    def test_empty_head(self):
+        """Check markdown with empty head."""
+        from markdown_pdf import MarkdownPdf, Section
+
+        pdf = MarkdownPdf(toc_level=2)
+        pdf.add_section(Section("# "))
+        pdf.save(self.build("empty-head.pdf"))


### PR DESCRIPTION
bump PyMuPDF up to 1.24.6.