### PR TITLE
Add optimize option for compressed output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ pip install markdown-pdf
 
 ## Usage
 
-Create a pdf with TOC (bookmarks) from headings up to level 2.
+Create a compressed pdf with TOC (bookmarks) from headings up to level 2.
 
 ```python
 from markdown_pdf import MarkdownPdf
 
-pdf = MarkdownPdf(toc_level=2)
+pdf = MarkdownPdf(toc_level=2, optimize=True)
 ```
 
 Add the first section to the pdf. The title is not included in the table of contents.

--- a/makepdf.py
+++ b/makepdf.py
@@ -1,7 +1,7 @@
 import sys
 from markdown_pdf import MarkdownPdf, Section
 
-pdf = MarkdownPdf(toc_level=4)
+pdf = MarkdownPdf(toc_level=4, optimize=True)
 pdf.add_section(Section(open(sys.argv[1], encoding='utf-8').read()))
 pdf.meta["title"] = "MarkdownPdf module"
 pdf.save(sys.argv[2])

--- a/markdown_pdf/__init__.py
+++ b/markdown_pdf/__init__.py
@@ -42,7 +42,7 @@ class MarkdownPdf:
       "keywords": None,
     }
 
-    def __init__(self, toc_level: int = 6, mode: str = 'commonmark'):
+    def __init__(self, toc_level: int = 6, mode: str = 'commonmark', optimize: bool = False):
         """Create md -> pdf converter with given TOC level and mode of md parsing."""
         self.toc_level = toc_level
         self.toc = []
@@ -50,6 +50,8 @@ class MarkdownPdf:
         # zero, commonmark, js-default, gfm-like
         # https://markdown-it-py.readthedocs.io/en/latest/using.html#quick-start
         self.m_d = (MarkdownIt(mode).enable('table'))  # Enable support for tables
+
+        self.optimize = optimize
 
         self.out_file = io.BytesIO()
         self.writer = fitz.DocumentWriter(self.out_file)
@@ -100,5 +102,8 @@ class MarkdownPdf:
         doc.set_metadata(self.meta)
         if self.toc_level > 0:
             doc.set_toc(self.toc)
-        doc.save(file_name)
+        if self.optimize:
+            doc.ez_save(file_name)
+        else:
+            doc.save(file_name)
         doc.close()


### PR DESCRIPTION
This change adds an `optimize` option which enables compression on the output file. The files in `examples` will shrink from 2M to 160k with this option enabled.

I called it `optimize` instead of `compress` because it uses the `ez_save` method which will enable different features depending on the PyMuPDF version used.