### PR TITLE
Add the ability to specify paper size in mm

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The `Section` class can set the following attributes.
 
 - toc: whether to include the headers `<h1>` - `<h6>` of this section in the TOC. Default is True.
 - root: the name of the root directory from which the image file paths starts in markdown. Default ".".
-- paper_size: name of paper size, [as described here](https://pymupdf.readthedocs.io/en/latest/functions.html#paper_size). Default "A4".
+- paper_size: either the name of a paper size, [as described here](https://pymupdf.readthedocs.io/en/latest/functions.html#paper_size), or a list containing the width and height in mm. Default "A4".
 - borders: size of borders. Default (36, 36, -36, -36).
 
 The following document properties are available for assignment (dictionary `MarkdownPdf.meta`) with the default values indicated.


### PR DESCRIPTION
Firstly, thanks for the great library :smile:. I've been using it to generate PDFs of labels to be printed from a thermal label printer and as such needed to support some unusual paper sizes. 

This PR adds the ability to specify a paper size in millimeters as a list `[width, height]` whilst retaining the existing functionality to use predefined paper sizes.