### PR TITLE
Allow markdown-it-py >=4.0.0 on Python >=3.10.

### DIFF
--- a/.github/workflows/py3.yml
+++ b/.github/workflows/py3.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         pymupdf-version: ['1.27.1', '1.26.7', '1.25.5']
+        markdown-it-py-version: ['4.2.0', '4.1.0', '4.0.0']
 
     steps:
     - uses: actions/checkout@v3
@@ -27,12 +28,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies with PyMuPDF==${{ matrix.pymupdf-version }}
+    - name: Install dependencies with PyMuPDF==${{ matrix.pymupdf-version }} and markdown-it-py==${{ matrix.markdown-it-py-version }}
       run: |
         python -m pip install --upgrade pip
         pip install '.[dev]'
-        # Override pymupdf with the matrix version
-        pip install "PyMuPDF==${{ matrix.pymupdf-version }}"
+        # Override pymupdf and markdown-it-py with the matrix versions
+        pip install "PyMuPDF==${{ matrix.pymupdf-version }}" "markdown-it-py==${{ matrix.markdown-it-py-version }}"
 
     - name: flake8
       run: |

--- a/history.txt
+++ b/history.txt
@@ -1,3 +1,8 @@
+28.05.2026 ver.1.13.2
+---------------------
+
+* Relax markdown-it-py pin: keep ==3.0.0 on Python <3.10, allow >=4.0.0 on Python >=3.10.
+
 * For Python 3.8 PyMuPDF version changed from 1.24.6 to 1.24.11.
 
 * For Python 3.9 use tests with PyMuPDF version 1.26.5.

--- a/history.txt
+++ b/history.txt
@@ -1,7 +1,4 @@
-28.05.2026 ver.1.13.2
----------------------
-
-* Relax markdown-it-py pin: keep ==3.0.0 on Python <3.10, allow >=4.0.0 on Python >=3.10.
++ Relax markdown-it-py pin: keep ==3.0.0 on Python <3.10, allow >=4.0.0 on Python >=3.10.
 
 * For Python 3.8 PyMuPDF version changed from 1.24.6 to 1.24.11.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "markdown_pdf"
-version = "1.13.1"
+version = "1.13.2"
 description = "Markdown to pdf renderer"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.8"
@@ -22,7 +22,8 @@ classifiers = [
 dependencies = [
     "PyMuPDF==1.24.11; python_version<'3.9'",
     "PyMuPDF>=1.25.3; python_version>'3.8'",
-    "markdown-it-py==3.0.0; python_version>='3.8'",
+    "markdown-it-py==3.0.0; python_version<'3.10'",
+    "markdown-it-py>=4.0.0; python_version>='3.10'",
     "requests==2.32.3; python_version<'3.9'",
     "requests>=2.32.5; python_version>'3.8'",
     "plantuml==0.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "markdown_pdf"
-version = "1.13.2"
+version = "1.13.1"
 description = "Markdown to pdf renderer"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.8"


### PR DESCRIPTION
The 4.0.0 release dropped Python 3.8/3.9 support, so split the pin:
==3.0.0 on Python <3.10, >=4.0.0 on Python >=3.10. Adds matrix
coverage for 4.0.0, 4.1.0, 4.2.0 to py3.yml. All 23 tests pass
locally on both 3.0.0 and 4.0.0.

Release notes: https://github.com/executablebooks/markdown-it-py/releases/tag/v4.0.0